### PR TITLE
modify railtie

### DIFF
--- a/lib/ddtrace.rb
+++ b/lib/ddtrace.rb
@@ -50,11 +50,7 @@ if defined?(Rails::VERSION)
         # This is required because the middleware stack is frozen after
         # the initialization and so it's too late to add our tracing
         # functionalities.
-        initializer :datadog_config, before: :build_middleware_stack do |app|
-          app.config.middleware.insert_before(
-            0, Datadog::Contrib::Rack::TraceMiddleware, options
-          )
-        end
+        config.app_middleware.insert_before(0, Datadog::Contrib::Rack::TraceMiddleware, options)
       end
     end
   else

--- a/lib/ddtrace/contrib/rack/middlewares.rb
+++ b/lib/ddtrace/contrib/rack/middlewares.rb
@@ -58,7 +58,7 @@ module Datadog
 
           # call the rest of the stack
           status, headers, response = @app.call(env)
-        rescue StandardError => e
+        rescue Exception => e
           # catch exceptions that may be raised in the middleware chain
           # Note: if a middleware catches an Exception without re raising,
           # the Exception cannot be recorded here


### PR DESCRIPTION
* add dd-trace directly to middleware stack, rather than going through an initializer
* rescue, report and re-raise all exceptions, not just `StandardErrors`

https://www.pivotaltracker.com/story/show/144318075

